### PR TITLE
feat: Add module-infos

### DIFF
--- a/aot/README.md
+++ b/aot/README.md
@@ -15,8 +15,9 @@ To enable use the AotMachine factory when building the module:
 // ...
 
 import com.dylibso.chicory.wasm.Parser;
+import com.dylibso.chicory.wasm.corpus.WasmCorpus;
 import com.dylibso.chicory.experimental.aot.AotMachine;
 // ...
-var is = ClassLoader.getSystemClassLoader().getResourceAsStream("compiled/basic.c.wasm");
+var is = WasmCorpus.getCompiledAsStream("basic.c.wasm");
 Instance.builder(Parser.parse(is)).withMachineFactory(AotMachine::new).build();
 ```

--- a/aot/pom.xml
+++ b/aot/pom.xml
@@ -57,4 +57,25 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-testCompile</id>
+            <configuration>
+              <compilerArgs>
+                <!-- required by approvaltests -->
+                <arg>--add-modules</arg>
+                <arg>java.sql</arg>
+              </compilerArgs>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/aot/src/main/java/module-info.java
+++ b/aot/src/main/java/module-info.java
@@ -1,7 +1,6 @@
 module chicory.aot {
     requires chicory.runtime;
     requires chicory.wasm;
-    requires static java.sql;
     requires org.objectweb.asm.commons;
     requires org.objectweb.asm.util;
 

--- a/aot/src/main/java/module-info.java
+++ b/aot/src/main/java/module-info.java
@@ -1,0 +1,9 @@
+module chicory.aot {
+    requires chicory.runtime;
+    requires chicory.wasm;
+    requires static java.sql;
+    requires org.objectweb.asm.commons;
+    requires org.objectweb.asm.util;
+
+    exports com.dylibso.chicory.experimental.aot;
+}

--- a/aot/src/test/java/com/dylibso/chicory/experimental/aot/InterruptionTest.java
+++ b/aot/src/test/java/com/dylibso/chicory/experimental/aot/InterruptionTest.java
@@ -11,16 +11,14 @@ import com.dylibso.chicory.runtime.Instance;
 import com.dylibso.chicory.wasm.ChicoryException;
 import com.dylibso.chicory.wasm.Parser;
 import com.dylibso.chicory.wasm.WasmModule;
+import com.dylibso.chicory.wasm.corpus.WasmCorpus;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.Test;
 
 public class InterruptionTest {
     @Test
     public void shouldInterruptLoop() throws InterruptedException {
-        var module =
-                Parser.parse(
-                        InterruptionTest.class.getResourceAsStream(
-                                "/compiled/infinite-loop.c.wasm"));
+        var module = Parser.parse(WasmCorpus.getCompiledAsStream("infinite-loop.c.wasm"));
         var instance = Instance.builder(module).withMachineFactory(AotMachine::new).build();
 
         var function = instance.export("run");
@@ -29,8 +27,7 @@ public class InterruptionTest {
 
     @Test
     public void shouldInterruptCall() throws InterruptedException {
-        var module =
-                Parser.parse(InterruptionTest.class.getResourceAsStream("/compiled/power.c.wasm"));
+        var module = Parser.parse(WasmCorpus.getCompiledAsStream("power.c.wasm"));
         var instance = Instance.builder(module).withMachineFactory(AotMachine::new).build();
         var function = instance.export("run");
         assertInterruption(() -> function.apply(100), functionIdx(module, "run"));

--- a/cli/src/main/java/module-info.java
+++ b/cli/src/main/java/module-info.java
@@ -1,0 +1,10 @@
+module chicory.cli {
+    requires chicory.runtime;
+    requires chicory.wasi;
+    requires chicory.wasm;
+    requires info.picocli;
+    requires java.logging;
+
+    opens com.dylibso.chicory.experimental.cli to
+            info.picocli;
+}

--- a/host-module/annotations/src/main/java/module-info.java
+++ b/host-module/annotations/src/main/java/module-info.java
@@ -1,0 +1,3 @@
+module chicory.hostmodule.annotations {
+    exports com.dylibso.chicory.experimental.hostmodule.annotations;
+}

--- a/host-module/processor/src/main/java/module-info.java
+++ b/host-module/processor/src/main/java/module-info.java
@@ -1,0 +1,12 @@
+module chicory.hostmodule.processor {
+    requires chicory.hostmodule.annotations;
+    requires chicory.wasm;
+    requires com.github.javaparser.core;
+    requires java.compiler;
+
+    provides javax.annotation.processing.Processor with
+            com.dylibso.chicory.experimental.hostmodule.processor.HostModuleProcessor,
+            com.dylibso.chicory.experimental.hostmodule.processor.WasmModuleProcessor;
+
+    exports com.dylibso.chicory.experimental.hostmodule.processor;
+}

--- a/host-module/processor/src/test/java/com/dylibso/chicory/experimental/hostmodule/processor/HostModuleProcessorTest.java
+++ b/host-module/processor/src/test/java/com/dylibso/chicory/experimental/hostmodule/processor/HostModuleProcessorTest.java
@@ -5,14 +5,23 @@ import static com.google.testing.compile.Compiler.javac;
 
 import com.google.testing.compile.Compilation;
 import com.google.testing.compile.JavaFileObjects;
+import java.io.File;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class HostModuleProcessorTest {
+
+    private static final Iterable<File> CLASSPATH =
+            List.of(
+                    new File("../annotations/target/classes"),
+                    new File("../../runtime/target/classes"),
+                    new File("../../wasm/target/classes"));
 
     @Test
     void generateModules() {
         Compilation compilation =
                 javac().withProcessors(new HostModuleProcessor())
+                        .withClasspath(CLASSPATH)
                         .compile(
                                 JavaFileObjects.forResource("BasicMath.java"),
                                 JavaFileObjects.forResource("Box.java"),
@@ -42,6 +51,7 @@ class HostModuleProcessorTest {
     void invalidParameterTypeUnsupported() {
         Compilation compilation =
                 javac().withProcessors(new HostModuleProcessor())
+                        .withClasspath(CLASSPATH)
                         .compile(JavaFileObjects.forResource("InvalidParameterUnsupported.java"));
 
         assertThat(compilation).failed();
@@ -56,6 +66,7 @@ class HostModuleProcessorTest {
     void invalidParameterTypeString() {
         Compilation compilation =
                 javac().withProcessors(new HostModuleProcessor())
+                        .withClasspath(CLASSPATH)
                         .compile(JavaFileObjects.forResource("InvalidParameterString.java"));
 
         assertThat(compilation).failed();
@@ -70,6 +81,7 @@ class HostModuleProcessorTest {
     void invalidReturnType() {
         Compilation compilation =
                 javac().withProcessors(new HostModuleProcessor())
+                        .withClasspath(CLASSPATH)
                         .compile(JavaFileObjects.forResource("InvalidReturn.java"));
 
         assertThat(compilation).failed();

--- a/jmh/src/main/java/module-info.java
+++ b/jmh/src/main/java/module-info.java
@@ -1,0 +1,6 @@
+module chicory.jmh {
+    requires chicory.aot;
+    requires chicory.runtime;
+    requires chicory.wasm;
+    requires static jmh.core;
+}

--- a/log/src/main/java/module-info.java
+++ b/log/src/main/java/module-info.java
@@ -1,0 +1,5 @@
+module chicory.log {
+    requires static com.google.errorprone.annotations;
+
+    exports com.dylibso.chicory.log;
+}

--- a/machine-tests/src/test/java/com/dylibso/chicory/testing/MachinesTest.java
+++ b/machine-tests/src/test/java/com/dylibso/chicory/testing/MachinesTest.java
@@ -21,6 +21,7 @@ import com.dylibso.chicory.wasi.WasiOptions;
 import com.dylibso.chicory.wasi.WasiPreview1;
 import com.dylibso.chicory.wasm.Parser;
 import com.dylibso.chicory.wasm.WasmModule;
+import com.dylibso.chicory.wasm.corpus.WasmCorpus;
 import com.dylibso.chicory.wasm.types.ExternalType;
 import com.dylibso.chicory.wasm.types.Table;
 import com.dylibso.chicory.wasm.types.TableLimits;
@@ -41,15 +42,15 @@ import org.junit.jupiter.api.Test;
 public final class MachinesTest {
 
     private WasmModule loadModule(String fileName) {
-        return Parser.parse(getClass().getResourceAsStream("/" + fileName));
+        return Parser.parse(WasmCorpus.getCompiledAsStream(fileName));
     }
 
     private Instance.Builder quickJsInstanceBuilder() {
-        return Instance.builder(loadModule("compiled/quickjs-provider.javy-dynamic.wasm"));
+        return Instance.builder(loadModule("quickjs-provider.javy-dynamic.wasm"));
     }
 
     private Instance.Builder moduleInstanceBuilder() {
-        return Instance.builder(loadModule("compiled/hello-world.js.javy-dynamic.wasm"));
+        return Instance.builder(loadModule("hello-world.js.javy-dynamic.wasm"));
     }
 
     private WasiPreview1 setupWasi(ByteArrayOutputStream stderr) {
@@ -230,13 +231,13 @@ public final class MachinesTest {
         store.addTable(new ImportTable("test", "table", table));
 
         var instance =
-                Instance.builder(loadModule("compiled/call_indirect-export.wat.wasm"))
+                Instance.builder(loadModule("call_indirect-export.wat.wasm"))
                         .withImportValues(store.toImportValues())
                         .withMachineFactory(InterpreterMachine::new)
                         .build();
         store.register("test", instance);
 
-        Instance.builder(loadModule("compiled/call_indirect-import.wat.wasm"))
+        Instance.builder(loadModule("call_indirect-import.wat.wasm"))
                 .withImportValues(store.toImportValues())
                 .withMachineFactory(AotMachine::new)
                 .build();
@@ -256,13 +257,13 @@ public final class MachinesTest {
         store.addTable(new ImportTable("test", "table", table));
 
         var instance =
-                Instance.builder(loadModule("compiled/call_indirect-export.wat.wasm"))
+                Instance.builder(loadModule("call_indirect-export.wat.wasm"))
                         .withImportValues(store.toImportValues())
                         .withMachineFactory(AotMachine::new)
                         .build();
         store.register("test", instance);
 
-        Instance.builder(loadModule("compiled/call_indirect-import.wat.wasm"))
+        Instance.builder(loadModule("call_indirect-import.wat.wasm"))
                 .withImportValues(store.toImportValues())
                 .withMachineFactory(InterpreterMachine::new)
                 .build();

--- a/pom.xml
+++ b/pom.xml
@@ -616,6 +616,9 @@
                 <module name="UnusedLocalVariable"/>
                 <module name="UpperEll"/>
               </module>
+              <module name="BeforeExecutionExclusionFileFilter">
+                <property name="fileNamePattern" value="module\-info\.java$"/>
+              </module>
             </module>
           </checkstyleRules>
         </configuration>

--- a/runtime/src/main/java/module-info.java
+++ b/runtime/src/main/java/module-info.java
@@ -1,0 +1,5 @@
+module chicory.runtime {
+    requires chicory.wasm;
+
+    exports com.dylibso.chicory.runtime;
+}

--- a/runtime/src/test/java/com/dylibso/chicory/runtime/InterruptionTest.java
+++ b/runtime/src/test/java/com/dylibso/chicory/runtime/InterruptionTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.dylibso.chicory.wasm.ChicoryException;
 import com.dylibso.chicory.wasm.Parser;
+import com.dylibso.chicory.wasm.corpus.WasmCorpus;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.Test;
 
@@ -17,8 +18,7 @@ public class InterruptionTest {
         var instance =
                 Instance.builder(
                                 Parser.parse(
-                                        InterruptionTest.class.getResourceAsStream(
-                                                "/compiled/infinite-loop.c.wasm")))
+                                        WasmCorpus.getCompiledAsStream("infinite-loop.c.wasm")))
                         .build();
         var function = instance.export("run");
         assertInterruption(function::apply);
@@ -27,10 +27,7 @@ public class InterruptionTest {
     @Test
     public void shouldInterruptCall() throws InterruptedException {
         var instance =
-                Instance.builder(
-                                Parser.parse(
-                                        InterruptionTest.class.getResourceAsStream(
-                                                "/compiled/power.c.wasm")))
+                Instance.builder(Parser.parse(WasmCorpus.getCompiledAsStream("power.c.wasm")))
                         .build();
         var function = instance.export("run");
         assertInterruption(() -> function.apply(100));

--- a/runtime/src/test/java/com/dylibso/chicory/runtime/StoreTest.java
+++ b/runtime/src/test/java/com/dylibso/chicory/runtime/StoreTest.java
@@ -6,13 +6,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.dylibso.chicory.wasm.Parser;
 import com.dylibso.chicory.wasm.WasmModule;
+import com.dylibso.chicory.wasm.corpus.WasmCorpus;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class StoreTest {
 
     private static WasmModule loadModule(String fileName) {
-        return Parser.parse(WasmModuleTest.class.getResourceAsStream("/" + fileName));
+        return Parser.parse(WasmCorpus.getCompiledAsStream(fileName));
     }
 
     @Test
@@ -30,7 +31,7 @@ public class StoreTest {
 
     @Test
     public void exportsShouldBeRegistered() {
-        var instance = Instance.builder(loadModule("compiled/exports.wat.wasm")).build();
+        var instance = Instance.builder(loadModule("exports.wat.wasm")).build();
         var store = new Store();
         String moduleName = "exports-module";
         store.register(moduleName, instance);
@@ -62,7 +63,7 @@ public class StoreTest {
     public void instantiateShouldRegisterInstance() {
         var store = new Store();
         String moduleName = "exports-module";
-        var inst = store.instantiate(moduleName, loadModule("compiled/exports.wat.wasm"));
+        var inst = store.instantiate(moduleName, loadModule("exports.wat.wasm"));
         assertNotNull(inst);
 
         // memories
@@ -93,10 +94,10 @@ public class StoreTest {
         var store = new Store();
 
         String name1 = "exports-module-1";
-        store.instantiate(name1, loadModule("compiled/exports.wat.wasm"));
+        store.instantiate(name1, loadModule("exports.wat.wasm"));
 
         String name2 = "exports-module-2";
-        store.instantiate(name2, loadModule("compiled/exports.wat.wasm"));
+        store.instantiate(name2, loadModule("exports.wat.wasm"));
 
         var names = List.of(name1, name2);
 
@@ -139,7 +140,7 @@ public class StoreTest {
         store.instantiate(
                 name1,
                 imports ->
-                        Instance.builder(loadModule("compiled/exports.wat.wasm"))
+                        Instance.builder(loadModule("exports.wat.wasm"))
                                 .withImportValues(imports)
                                 .withStart(false)
                                 .build());
@@ -148,7 +149,7 @@ public class StoreTest {
         store.instantiate(
                 name2,
                 imports ->
-                        Instance.builder(loadModule("compiled/exports.wat.wasm"))
+                        Instance.builder(loadModule("exports.wat.wasm"))
                                 .withImportValues(imports)
                                 .build());
 

--- a/simd/src/main/java/module-info.java
+++ b/simd/src/main/java/module-info.java
@@ -1,0 +1,7 @@
+module chicory.simd {
+    requires chicory.runtime;
+    requires chicory.wasm;
+    requires jdk.incubator.vector;
+
+    exports com.dylibso.chicory.simd;
+}

--- a/simd/src/test/java/com/dylibso/chicory/simd/BasicSimdTest.java
+++ b/simd/src/test/java/com/dylibso/chicory/simd/BasicSimdTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.dylibso.chicory.runtime.Instance;
 import com.dylibso.chicory.wasm.Parser;
+import com.dylibso.chicory.wasm.corpus.WasmCorpus;
 import org.junit.jupiter.api.Test;
 
 public class BasicSimdTest {
@@ -14,8 +15,7 @@ public class BasicSimdTest {
         var instance =
                 Instance.builder(
                                 Parser.parse(
-                                        BasicSimdTest.class.getResourceAsStream(
-                                                "/compiled/simd-example.wat.wasm")))
+                                        WasmCorpus.getCompiledAsStream("simd-example.wat.wasm")))
                         .withMachineFactory(SimdInterpreterMachine::new)
                         .build();
         var main = instance.export("main");

--- a/wabt/src/main/java/module-info.java
+++ b/wabt/src/main/java/module-info.java
@@ -1,0 +1,9 @@
+module chicory.wabt {
+    requires chicory.log;
+    requires chicory.runtime;
+    requires chicory.wasi;
+    requires chicory.wasm;
+    requires com.google.common.jimfs;
+
+    exports com.dylibso.chicory.wabt;
+}

--- a/wasi/src/main/java/module-info.java
+++ b/wasi/src/main/java/module-info.java
@@ -1,0 +1,11 @@
+module chicory.wasi {
+    requires static chicory.hostmodule.annotations;
+    requires chicory.log;
+    requires chicory.runtime;
+    requires chicory.wasm;
+    requires static java.compiler;
+
+    uses javax.annotation.processing.Processor;
+
+    exports com.dylibso.chicory.wasi;
+}

--- a/wasm-corpus/src/main/java/com/dylibso/chicory/wasm/corpus/WasmCorpus.java
+++ b/wasm-corpus/src/main/java/com/dylibso/chicory/wasm/corpus/WasmCorpus.java
@@ -1,0 +1,23 @@
+package com.dylibso.chicory.wasm.corpus;
+
+import java.io.InputStream;
+
+/**
+ * A bundle of wasm files for testing purposes.
+ */
+public final class WasmCorpus {
+
+    /** Private constructor to prevent instantiation. */
+    private WasmCorpus() {
+        // nothing to do
+    }
+
+    /**
+     * Gets the compiled wasm with given name as a stream.
+     *
+     * @return the wasm as a stream, or {@code null} if not found
+     */
+    public static InputStream getCompiledAsStream(final String name) {
+        return WasmCorpus.class.getResourceAsStream("/compiled/" + name);
+    }
+}

--- a/wasm-corpus/src/main/java/module-info.java
+++ b/wasm-corpus/src/main/java/module-info.java
@@ -1,0 +1,3 @@
+module chicory.wasm.corpus {
+    exports com.dylibso.chicory.wasm.corpus;
+}

--- a/wasm-tools/src/main/java/module-info.java
+++ b/wasm-tools/src/main/java/module-info.java
@@ -1,0 +1,9 @@
+module chicory.wasm.tools {
+    requires chicory.log;
+    requires chicory.runtime;
+    requires chicory.wasi;
+    requires chicory.wasm;
+    requires com.google.common.jimfs;
+
+    exports com.dylibso.chicory.tools.wasm;
+}

--- a/wasm/src/main/java/module-info.java
+++ b/wasm/src/main/java/module-info.java
@@ -1,0 +1,4 @@
+module chicory.wasm {
+    exports com.dylibso.chicory.wasm;
+    exports com.dylibso.chicory.wasm.types;
+}

--- a/wasm/src/test/java/com/dylibso/chicory/wasm/ParserTest.java
+++ b/wasm/src/test/java/com/dylibso/chicory/wasm/ParserTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import com.dylibso.chicory.wasm.corpus.WasmCorpus;
 import com.dylibso.chicory.wasm.types.ActiveDataSegment;
 import com.dylibso.chicory.wasm.types.CustomSection;
 import com.dylibso.chicory.wasm.types.ExternalType;
@@ -30,7 +31,7 @@ public class ParserTest {
 
     @Test
     public void shouldParseFile() throws IOException {
-        try (InputStream is = getClass().getResourceAsStream("/compiled/start.wat.wasm")) {
+        try (InputStream is = WasmCorpus.getCompiledAsStream("start.wat.wasm")) {
             var module = Parser.parse(is);
 
             // check types section
@@ -93,7 +94,7 @@ public class ParserTest {
 
     @Test
     public void shouldParseIterfact() throws IOException {
-        try (InputStream is = getClass().getResourceAsStream("/compiled/iterfact.wat.wasm")) {
+        try (InputStream is = WasmCorpus.getCompiledAsStream("iterfact.wat.wasm")) {
             var module = Parser.parse(is);
 
             // check types section
@@ -133,7 +134,7 @@ public class ParserTest {
     public void shouldSupportCustomListener() throws IOException {
         var parser = Parser.builder().includeSectionId(SectionId.CUSTOM).build();
 
-        try (InputStream is = getClass().getResourceAsStream("/compiled/count_vowels.rs.wasm")) {
+        try (InputStream is = WasmCorpus.getCompiledAsStream("count_vowels.rs.wasm")) {
             parser.parse(
                     is,
                     s -> {
@@ -150,7 +151,7 @@ public class ParserTest {
 
     @Test
     public void shouldParseFloats() throws IOException {
-        try (InputStream is = getClass().getResourceAsStream("/compiled/float.wat.wasm")) {
+        try (InputStream is = WasmCorpus.getCompiledAsStream("float.wat.wasm")) {
             var module = Parser.parse(is);
             var codeSection = module.codeSection();
             var fbody = codeSection.getFunctionBody(0);
@@ -163,7 +164,7 @@ public class ParserTest {
 
     @Test
     public void shouldProperlyParseSignedValue() throws IOException {
-        try (InputStream is = getClass().getResourceAsStream("/compiled/i32.wat.wasm")) {
+        try (InputStream is = WasmCorpus.getCompiledAsStream("i32.wat.wasm")) {
             var module = Parser.parse(is);
             var codeSection = module.codeSection();
             var fbody = codeSection.getFunctionBody(0);
@@ -186,7 +187,7 @@ public class ParserTest {
 
     @Test
     public void shouldParseLocalDefinitions() throws Exception {
-        try (InputStream is = getClass().getResourceAsStream("/compiled/define-locals.wat.wasm")) {
+        try (InputStream is = WasmCorpus.getCompiledAsStream("define-locals.wat.wasm")) {
             var module = Parser.parse(is);
             var codeSection = module.codeSection();
             var fbody = codeSection.getFunctionBody(0);
@@ -197,7 +198,7 @@ public class ParserTest {
 
     @Test
     public void shouldParseNamesSection() throws IOException {
-        try (InputStream is = getClass().getResourceAsStream("/compiled/count_vowels.rs.wasm")) {
+        try (InputStream is = WasmCorpus.getCompiledAsStream("count_vowels.rs.wasm")) {
             var module = Parser.parse(is);
             var nameSec = module.nameSection();
             assertEquals(module.codeSection().functionBodyCount(), nameSec.functionNameCount());

--- a/wasm/src/test/java/com/dylibso/chicory/wasm/WasmModuleTest.java
+++ b/wasm/src/test/java/com/dylibso/chicory/wasm/WasmModuleTest.java
@@ -3,30 +3,24 @@ package com.dylibso.chicory.wasm;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.dylibso.chicory.wasm.corpus.WasmCorpus;
+import java.io.IOException;
 import org.junit.jupiter.api.Test;
 
 public class WasmModuleTest {
 
     @Test
     public void shouldHaveTheSameHashCode() {
-        var mod1 =
-                Parser.parse(
-                        WasmModuleTest.class.getResourceAsStream("/compiled/count_vowels.rs.wasm"));
-        var mod2 =
-                Parser.parse(
-                        WasmModuleTest.class.getResourceAsStream("/compiled/count_vowels.rs.wasm"));
+        var mod1 = Parser.parse(WasmCorpus.getCompiledAsStream("count_vowels.rs.wasm"));
+        var mod2 = Parser.parse(WasmCorpus.getCompiledAsStream("count_vowels.rs.wasm"));
 
         assertEquals(mod1.hashCode(), mod2.hashCode());
     }
 
     @Test
-    public void shouldBeEquals() {
-        var mod1 =
-                Parser.parse(
-                        WasmModuleTest.class.getResourceAsStream("/compiled/count_vowels.rs.wasm"));
-        var mod2 =
-                Parser.parse(
-                        WasmModuleTest.class.getResourceAsStream("/compiled/count_vowels.rs.wasm"));
+    public void shouldBeEquals() throws IOException {
+        var mod1 = Parser.parse(WasmCorpus.getCompiledAsStream("count_vowels.rs.wasm"));
+        var mod2 = Parser.parse(WasmCorpus.getCompiledAsStream("count_vowels.rs.wasm"));
 
         assertTrue(mod1.equals(mod2));
     }


### PR DESCRIPTION
| Maven project | Java module | Status |
|--------|---------|--------|
| aot        | chicory.aot              | 🚧           | 
| aot-build-time | |
| aot-build-time-cli | |
| aot-maven-plugin | |
| aot-tests | |
| bom | |
| cli | chicory.cli | ✅ |
| docs-lib | |
| fuzz ||
| host-module-annotation | chicory.hostmodule.annotation | ✅ |
| host-module-it | |
| host-module-processor |chicory.hostmodule.processor | 🚧 |
| jmh | |
| log | chicory.log | ✅ |
| machine-tests | |
| runtime | chicory.runtime | ✅ |
| runtime-tests | |
| simd | chicory.simd | ✅ |
| test-gen-lib | |
| test-gen-plugin | |
| wabt | chicory.wabt | ✅ |
| wasi | chicory.wasi | ✅ |
| wasi-test-gen-plugin | |
| wasi-tests | |
| wasm | chicory.wasm | ✅  |
| wasm-corpus | chicory.wasm.corpus | ✅ |
| wasm-tools | chicory.wasm.tools | ✅ |

TODO:

- [x] For tests relying on `wasm-corpys`: See if there is a cleaner way to access files than doing a `Files.newInputStream()` with relative path -> Create a `WasmCorpus` class to access resources
- [ ] For `host-module-processor` tests: See if there is a better way than specifying a custom classpath
